### PR TITLE
Update links.yml

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -14,11 +14,16 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - name: Remove symlink
+        run: rm docs/source/README.md
       - name: lychee Link Checker
         id: lychee
         uses: lycheeverse/lychee-action@v1.5.0
         with:
-          args: --accept=200,403,429  "**/*.html" "**/*.md" "**/*.txt" "**/*.json" --exclude "file:///github/workspace/*" --exclude-mail
+          args: --accept=200,403,429 "**/*.html" "**/*.md" "**/*.txt" "**/*.json" --exclude "file:///github/workspace/*" --exclude "file:///home/runner/work/opensearch-py/opensearch-py/docs/source/README.md" --exclude-mail 
           fail: true
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      - name: Restore symlink
+        if: always()
+        run: ln -s ../../README.md docs/source/README.md


### PR DESCRIPTION
Bug fix, 
made modifications to the links.yml workflow file to address the issue with relative links in the README.md.

Here's a summary of the changes:

Added a new step before the link checking process. This step removes the symbolic link (soft link) of README.md in the docs/source directory. This prevents the link checker from incorrectly resolving relative links due to the presence of this soft copy.

In the arguments section of the lychee Link Checker, I've added an exclusion for the file reference to the docs/source/README.md. This exclusion is necessary because even though we've removed the soft link, other parts of the project or external references might still point to this location. By excluding it from the link check, we ensure that the checker doesn't attempt to validate any links that might reference this now-nonexistent soft link. This prevents potential false positives or errors that could arise from references to the removed soft link.

After the link checking is complete, I've added another step to recreate the soft link. This ensures that the repository structure remains intact and doesn't affect other workflows that might depend on the presence of this soft link.
